### PR TITLE
Change namespace to "kong"

### DIFF
--- a/kubernetes/blue.yaml
+++ b/kubernetes/blue.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: blue
+  namespace: kong
   labels:
     app: kong
     name: oauth-token-generator

--- a/kubernetes/deployment-nginx.yaml
+++ b/kubernetes/deployment-nginx.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-proxy
+  namespace: kong
   labels:
     app: nginx-proxy
 spec:

--- a/kubernetes/green.yaml
+++ b/kubernetes/green.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: green
+  namespace: kong
   labels:
     app: kong
     name: oauth-token-generator

--- a/kubernetes/namespace.yaml
+++ b/kubernetes/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: default
+  name: kong

--- a/kubernetes/service-kong-oauth-token-generator.yaml
+++ b/kubernetes/service-kong-oauth-token-generator.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: oauth-token-generator
+  namespace: kong
   labels:
     app: kong
     name: oauth-token-generator

--- a/kubernetes/service-nginx.yaml
+++ b/kubernetes/service-nginx.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx-proxy
+  namespace: kong
   labels:
     app: nginx-proxy
 spec:


### PR DESCRIPTION
# WHY

`namespace` of Kubernetes is `default`.
# WHAT

Changed `namespace` to `kong`.
